### PR TITLE
fix: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to immutable commit SHAs (prevents tag/branch force-push attacks)
- Add Dependabot configuration for automatic GitHub Actions version updates

## Context

On 2026-03-19, `aquasecurity/trivy-action` was compromised via a tag force-push attack that exfiltrated secrets from CI runners. SHA-pinning prevents this class of attack entirely.

The netresearch org now enforces `sha_pinning_required=true` — workflows using tag/branch references will fail.

Ref: https://github.com/netresearch/ofelia/issues/535

## Test plan

- [ ] Verify CI passes with SHA-pinned actions
- [ ] Verify Dependabot creates PRs for action updates