### PR TITLE
ci: call the shared auto-merge reusable

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,73 +1,22 @@
-# Auto-merge dependency updates for repositories WITHOUT branch protection
-# Uses direct merge since --auto flag requires branch protection
 name: Auto-merge dependency PRs
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
+# Thin caller: the whole gate lives in the shared reusable, so the pinned
+# action versions and the merge policy stay maintained centrally.
+#
+# This repo genuinely has auto-merge disabled (allow_auto_merge=false, no
+# branch protection). That is exactly why it used to keep its own copy:
+# `gh pr merge --auto` fails here, and simply dropping the flag would merge
+# the PR before CI reported. The reusable now detects that case and waits
+# for the checks itself, so the local copy is no longer needed.
 jobs:
   auto-merge:
-    name: Auto-merge dependency PRs
-    runs-on: ubuntu-latest
-    # Use PR author login instead of github.actor to handle synchronize events
-    # when someone else pushes to the dependabot/renovate branch
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Dependabot metadata
-        id: metadata
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Auto-approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Wait for CI checks
-        run: |
-          echo "Waiting for CI checks to complete..."
-          for i in {1..60}; do
-            CHECKS=$(gh pr checks "$PR_URL" --json name,state \
-              --jq '[.[] | select(.name != "Auto-merge dependency PRs")]')
-
-            FAILED=$(echo "$CHECKS" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
-            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length')
-
-            if [ "$FAILED" != "0" ]; then
-              echo "Some checks failed, skipping merge"
-              exit 1
-            fi
-
-            if [ "$PENDING" = "0" ]; then
-              echo "All checks passed!"
-              exit 0
-            fi
-
-            echo "Waiting for $PENDING check(s)... (attempt $i/60)"
-            sleep 10
-          done
-          echo "Timeout waiting for checks"
-          exit 1
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Merge PR
-        run: gh pr merge --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
Replaces a 60-line local copy of the auto-merge workflow with a four-line caller. Net **-64/+13**.

Unlike its siblings, this repo's copy was **genuinely necessary** until now:

```
allow_auto_merge = false
branch protection = none
```

`gh pr merge --auto` fails outright here, and simply dropping the flag would be worse than failing — without auto-merge nothing holds the merge back, so the PR would land *immediately*, before CI reported. The polling loop was the only thing gating the merge.

Rather than leaving the copy in place, the shared reusable was raised to cover this case: it now detects `allow_auto_merge` and waits for the checks itself where GitHub cannot ([netresearch/.github#289](https://github.com/netresearch/.github/pull/289)). That change was verified against five scenarios with a stubbed `gh` — all green, one red, one cancelled, permanently pending, and a failing API call — and only the first merges.

The behaviour here is therefore unchanged in substance: wait for the checks, merge if they pass, leave the PR approved-but-open if they do not.